### PR TITLE
Add args for customize

### DIFF
--- a/autoload/gotests.vim
+++ b/autoload/gotests.vim
@@ -34,9 +34,8 @@ function! gotests#tests() range
     endif
 
     let file = expand('%')
-    echom 'hello'
     let out = system(bin . args . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
-    echom 'gotests-vim: ' . out
+    echom 'gotests-vim: hello' . out
 endfunction
 
 

--- a/autoload/gotests.vim
+++ b/autoload/gotests.vim
@@ -2,7 +2,6 @@ scriptencoding utf-8
 
 function! gotests#tests() range
     let bin = g:gotests_bin
-    let args = g:gotests_args
     if !executable(bin)
         echom 'gotests-vim: gotests binary not found.'
         return
@@ -29,9 +28,14 @@ function! gotests#tests() range
 		let tmplDir = '-template ' . shellescape(g:gotests_template)
     endif
 
+    let args = ''
+    if (!empty(g:gotests_args))
+        let args = ' ' . shellescape(g:gotests_args)
+    endif
+
     let file = expand('%')
     echom 'hello'
-    let out = system(bin . ' ' . args . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
+    let out = system(bin . args . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
     echom 'gotests-vim: ' . out
 endfunction
 
@@ -51,7 +55,12 @@ function! gotests#alltests() abort
 		let tmplDir = '-template ' . shellescape(g:gotests_template)
     endif
 
+    let args = ''
+    if (!empty(g:gotests_args))
+        let args = ' ' . shellescape(g:gotests_args)
+    endif
+
     let file = expand('%')
-    let out = system(bin . ' ' . args . ' ' . ' -w -all ' . tmplDir . ' ' . shellescape(file))
+    let out = system(bin . args . ' ' . ' -w -all ' . tmplDir . ' ' . shellescape(file))
     echom 'gotests-vim: ' out
 endfunction

--- a/autoload/gotests.vim
+++ b/autoload/gotests.vim
@@ -35,7 +35,7 @@ function! gotests#tests() range
 
     let file = expand('%')
     let out = system(bin . args . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
-    echom 'gotests-vim: hello' . out
+    echom 'gotests-vim: ' . out
 endfunction
 
 
@@ -61,5 +61,5 @@ function! gotests#alltests() abort
 
     let file = expand('%')
     let out = system(bin . args . ' ' . ' -w -all ' . tmplDir . ' ' . shellescape(file))
-    echom 'gotests-vim: ' out
+    echom 'gotests-vim: ' . out
 endfunction

--- a/autoload/gotests.vim
+++ b/autoload/gotests.vim
@@ -2,6 +2,7 @@ scriptencoding utf-8
 
 function! gotests#tests() range
     let bin = g:gotests_bin
+    let args = g:gotests_args
     if !executable(bin)
         echom 'gotests-vim: gotests binary not found.'
         return
@@ -29,13 +30,15 @@ function! gotests#tests() range
     endif
 
     let file = expand('%')
-    let out = system(bin . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
+    echom 'hello'
+    let out = system(bin . ' ' . args . ' -w -only ' . shellescape(funcMatch) . ' ' . tmplDir . ' ' . shellescape(file))
     echom 'gotests-vim: ' . out
 endfunction
 
 
 function! gotests#alltests() abort
     let bin = g:gotests_bin
+    let args = g:gotests_args
     if !executable(bin)
         echom 'gotests-vim: gotests binary not found.'
         return
@@ -49,6 +52,6 @@ function! gotests#alltests() abort
     endif
 
     let file = expand('%')
-    let out = system(bin . ' -w -all ' . tmplDir . ' ' . shellescape(file))
+    let out = system(bin . ' ' . args . ' ' . ' -w -all ' . tmplDir . ' ' . shellescape(file))
     echom 'gotests-vim: ' out
 endfunction

--- a/plugin/vim-gotests.vim
+++ b/plugin/vim-gotests.vim
@@ -14,5 +14,9 @@ if !exists('g:gotests_template_dir')
     let g:gotests_template_dir = ''
 endif
 
+if !exists('g:gotests_args')
+    let g:gotests_args = ''
+endif
+
 command! -range GoTests <line1>,<line2>call gotests#tests()
 command! GoTestsAll call gotests#alltests()


### PR DESCRIPTION
GoTest command support some [args](https://github.com/cweill/gotests/blob/develop/gotests/main.go#L10-L42). We would like to have args for customize with `g:gotests_args`.

For example:
```
let g:gotests_args = '-parallel'
``` 

in ./vimrc file