### PR TITLE
Format installation list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Gotests-vim requires **gotests** to be available in your `$PATH`. Alternatively 
 can provide path to **gotests** using `g:gotests_bin` setting.
 
 Plugin installation:
-*  [Pathogen](https://github.com/tpope/vim-pathogen)
+* [Pathogen](https://github.com/tpope/vim-pathogen)
   * `git clone https://github.com/buoto/gotests-vim.git ~/.vim/bundle/gotests-vim`
-*  [vim-plug](https://github.com/junegunn/vim-plug)
+* [vim-plug](https://github.com/junegunn/vim-plug)
   * `Plug 'buoto/gotests-vim'`
-*  [NeoBundle](https://github.com/Shougo/neobundle.vim)
+* [NeoBundle](https://github.com/Shougo/neobundle.vim)
   * `NeoBundle 'buoto/gotests-vim'`
-*  [Vundle](https://github.com/gmarik/vundle)
+* [Vundle](https://github.com/gmarik/vundle)
   * `Plugin 'buoto/gotests-vim'`
-*  [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages) (since Vim 7.4.1528)
+* [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages) (since Vim 7.4.1528)
   * `git clone https://github.com/buoto/gotests-vim.git ~/.vim/pack/plugins/start/gotests-vim`
 
 ## Settings


### PR DESCRIPTION
This cleans up the markdown formatting for the installation list so it renders as sub-bulleted lists.